### PR TITLE
Phase 3.5 — revert scroll-to-zoom (dense graphs)

### DIFF
--- a/src/components/graph/GraphCanvas.test.tsx
+++ b/src/components/graph/GraphCanvas.test.tsx
@@ -101,16 +101,23 @@ describe('GraphCanvas — zoom and pan wiring', () => {
     expect(props.maxZoom).toBe(2.5);
   });
 
-  it('scroll-wheel and pinch zoom default on; trackpad pans via drag, not scroll', () => {
+  it('scroll = pan, pinch = zoom, drag = pan — matches every map/design tool', () => {
     render(<GraphCanvas />);
     const props = reactFlowProps.mock.calls[0]?.[0] ?? {};
-    // panOnScroll must be explicitly false so scroll is zoom, not pan.
-    expect(props.panOnScroll).toBe(false);
-    // panOnDrag stays on so middle-click / space-drag still pans.
+    // panOnScroll true so scroll-wheel and two-finger trackpad pan
+    // the canvas. Commit 4's scroll-to-zoom flip broke drag-pan on
+    // dense graphs (no empty space to grab), so we're back on RF's
+    // natural default. Cmd/Ctrl + scroll still zooms via RF's
+    // built-in zoomActivationKeyCode (default = Meta).
+    expect(props.panOnScroll).toBe(true);
+    // zoomOnScroll must be explicitly false — otherwise scroll both
+    // pans AND zooms, which is chaos.
+    expect(props.zoomOnScroll).toBe(false);
+    // panOnDrag stays on for middle-click / space-drag / empty-area
+    // drag pans; nodesDraggable is false so node drags fall through
+    // to canvas drag when they start inside a node's footprint.
     expect(props.panOnDrag).toBe(true);
-    // zoomOnScroll / zoomOnPinch must NOT be explicitly false; RF's
-    // defaults (true) are what we want here.
-    expect(props.zoomOnScroll).toBeUndefined();
+    // zoomOnPinch left as RF default (true) so trackpad pinch zooms.
     expect(props.zoomOnPinch).toBeUndefined();
   });
 

--- a/src/components/graph/GraphCanvas.tsx
+++ b/src/components/graph/GraphCanvas.tsx
@@ -212,7 +212,15 @@ function GraphCanvasInner() {
         maxZoom={2.5}
         translateExtent={translateExtent}
         panOnDrag
-        panOnScroll={false}
+        // Scroll = pan (matches every map/design tool). Commit 4
+        // originally flipped this to scroll-to-zoom, but real usage
+        // with 6+ subtask plans made canvas drag-pan unreliable —
+        // empty space became rare so every drag started on a node.
+        // Falling back to RF's natural defaults: scroll pans;
+        // Cmd/Ctrl + scroll zooms (via zoomActivationKeyCode); pinch
+        // zooms; keyboard +/- zooms (see useZoomShortcuts); 0 fits.
+        panOnScroll
+        zoomOnScroll={false}
         zoomOnDoubleClick={false}
         nodesDraggable={false}
         nodesConnectable={false}


### PR DESCRIPTION
## Summary

Last Phase 3.5 fix. Commit 4's scroll-to-zoom decision was wrong in practice: with 6+ subtask plans the canvas has almost no empty space, so drag-pan starts on a node and the gesture gets eaten before panOnDrag can take over. User can't reliably pan once the plan fans out.

Flipping back to React Flow's natural defaults:

- `panOnScroll={true}` — scroll pans (map/design-tool convention)
- `zoomOnScroll={false}` — explicit guard, no scroll-both-directions chaos
- `zoomOnPinch` default (true) — trackpad pinch still zooms
- `panOnDrag` unchanged — middle-click / space-drag / empty-area drag still pans
- Keyboard `+`/`-`/`0` and the Controls component from commit 4 stay exactly as they are
- Cmd/Ctrl + scroll zooms for free via RF's `zoomActivationKeyCode` default

Closes Phase 3.5.

## Test plan

- [x] `pnpm test` — 522/522
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [ ] Manual: launch a 6-subtask task, approve, scroll with mouse wheel — canvas pans vertically without dragging nodes around
- [ ] Manual: hold Cmd + scroll — canvas zooms
- [ ] Manual: trackpad pinch — canvas zooms
- [ ] Manual: keyboard `+` / `-` / `0` still work